### PR TITLE
Fix end of animation bug

### DIFF
--- a/src/vivus.js
+++ b/src/vivus.js
@@ -432,10 +432,10 @@ Vivus.prototype.trace = function () {
       this.renderPath(i);
     }
     if (path.progress == 1) {
-		  path.el.style.strokeDashoffset = null;
-		  path.el.style.strokeDasharray = null;
-		  this.renderPath(i);
-	  }
+      path.el.style.strokeDashoffset = null;
+      path.el.style.strokeDasharray = null;
+      this.renderPath(i);
+    }
   }
 };
 

--- a/src/vivus.js
+++ b/src/vivus.js
@@ -431,6 +431,11 @@ Vivus.prototype.trace = function () {
       path.el.style.strokeDashoffset = Math.floor(path.length * (1 - progress));
       this.renderPath(i);
     }
+    if (path.progress == 1) {
+		  path.el.style.strokeDashoffset = null;
+		  path.el.style.strokeDasharray = null;
+		  this.renderPath(i);
+	  }
   }
 };
 


### PR DESCRIPTION
At the end of animation path not closed.
Bug occurs only in chrome and firefox, in IE drawing works correctly.
Demonstration of trouble can be found here
https://lvlb.ru/vivusbug/
This path fix this problem.
![2018-08-04_14-38-19](https://user-images.githubusercontent.com/20488691/43676193-eac266e8-97f4-11e8-9c34-e7f708f0ba55.jpg)
